### PR TITLE
Switch to Mac OS X 10.6 deployment target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,13 +27,13 @@ if(UNIX AND NOT APPLE AND NOT DATA_DIR)
 	set(DATA_DIR "${CMAKE_INSTALL_PREFIX}/share/tagainijisho")
 endif(UNIX AND NOT APPLE AND NOT DATA_DIR)
 
-# Universal binary 32bits with 10.4 compatibility 
+# 64 bits Intel binary with 10.6 compatibility 
 if(APPLE)
 	set(CMAKE_OSX_ARCHITECTURES "x86_64")
 	set(CMAKE_OSX_SYSROOT /Developer/SDKs/MacOSX10.6.sdk)
 	set(CMAKE_C_COMPILER "gcc-4.2")
 	set(CMAKE_CXX_COMPILER "g++-4.2")
-	set(CMAKE_OSX_DEPLOYMENT_TARGET 10.4)
+	set(CMAKE_OSX_DEPLOYMENT_TARGET 10.6)
 	set(CMAKE_PREFIX_PATH "${CMAKE_OSX_SYSROOT}/usr")  
 	set(CMAKE_FRAMEWORK_PATH "${CMAKE_OSX_SYSROOT}/Library/Frameworks:${CMAKE_OSX_SYSROOT}/System/")
 endif(APPLE)


### PR DESCRIPTION
This ends support 10.5 and bellow. It was removed from lastest XCode release and hacking it back is too much of a hassle since we don't even have a test system.
