### PR TITLE
Show kun readings on a new line.

### DIFF
--- a/src/gui/kanjidic2/Kanjidic2EntryFormatter.cc
+++ b/src/gui/kanjidic2/Kanjidic2EntryFormatter.cc
@@ -246,7 +246,6 @@ void Kanjidic2EntryFormatter::drawCustom(const ConstKanjidic2EntryPointer& entry
 			painter.drawText(textBB, Qt::AlignLeft, str);
 			painter.setFont(textFont);
 			tempBox.setLeft(textBB.right());
-			tempBox.setRight(rightArea.center().x());
 			str = " " + onRead.join(", ");
 			str = QFontMetrics(painter.font(), painter.device()).elidedText(str, Qt::ElideRight, (int) tempBox.width());
 			onLength += (int) (painter.boundingRect(tempBox, Qt::AlignLeft, str).width());
@@ -258,8 +257,8 @@ void Kanjidic2EntryFormatter::drawCustom(const ConstKanjidic2EntryPointer& entry
 	if (printKunyomi) {
 		QStringList kunRead = entry->kunyomiReadings();
 		if (!kunRead.isEmpty()) {
-			tempBox.setLeft(rightArea.center().x());
-			tempBox.setRight(rightArea.right());
+			tempBox.setLeft(rightArea.left());
+			tempBox.setTop(textBB.bottom());
 			str = "Kun:";
 			painter.setFont(boldFont);
 			textBB = painter.boundingRect(tempBox, Qt::AlignLeft, str);


### PR DESCRIPTION
On the mailing list, <a href="https://groups.google.com/d/topic/tagaini-jisho/dpbdG7njvZQ/discussion">it was requested</a> that entries, when printed, give more room to the readings. The current behavior is that kun and on readings are placed on a single line, with exactly half a line allotted for each. I've changed it so that kun and on readings are printed on separate lines.
