### PR TITLE
Fixes incorrect focus during training

### DIFF
--- a/src/gui/YesNoTrainer.cc
+++ b/src/gui/YesNoTrainer.cc
@@ -128,6 +128,7 @@ void YesNoTrainer::train(const EntryPointer &entry)
 	goodAnswerButton->setEnabled(false);
 	wrongAnswerButton->setEnabled(false);
 	skipButton->setEnabled(true);
+	showAnswerButton->setFocus();
 	
 	QTextDocument *document(_detailedView->detailedView()->document());
 


### PR DESCRIPTION
I found a bug while using the training functions.
In a seemingly random fashion (sometimes it worked, other didn't, might have something to do with changing workspaces), the focus of the window changed and I couldn't use the keyboard shortcut (1) to go to the next word. This problem remained on the latest version cloned from git.

This simple commit forces the focus to the first button and the problem is resolved in all situations. Since there are no open issues about this, I assume I'm the only one that has this problem. Either way, this fixes it for me and doesn't seem to have any side effects.
