### PR TITLE
Enable button mnemonics (shortcuts) for Mac OS X. Right now

### DIFF
--- a/src/gui/YesNoTrainer.cc
+++ b/src/gui/YesNoTrainer.cc
@@ -128,7 +128,6 @@ void YesNoTrainer::train(const EntryPointer &entry)
 	goodAnswerButton->setEnabled(false);
 	wrongAnswerButton->setEnabled(false);
 	skipButton->setEnabled(true);
-	showAnswerButton->setFocus();
 	
 	QTextDocument *document(_detailedView->detailedView()->document());
 

--- a/src/gui/main.cc
+++ b/src/gui/main.cc
@@ -178,9 +178,15 @@ void checkUserProfileDirectory()
 
 int main(int argc, char *argv[])
 {
+	extern void qt_set_sequence_auto_mnemonic(bool b);
+
 	// Seed the random number generator
 	qsrand(QDateTime::currentDateTime().toTime_t());
 	QApplication app(argc, argv);
+
+	// Enable auto-mnemonics for Mac OS X. Ideally this would only
+	// be called on Mac OS X.
+	qt_set_sequence_auto_mnemonic(true);
 
 	QCoreApplication::setOrganizationDomain(__ORGANIZATION_NAME);
 	QCoreApplication::setApplicationName(__APPLICATION_NAME);


### PR DESCRIPTION
Enable button mnemonics (shortcuts) for Mac OS X. Right now the call to qt_set_sequence_auto_mnemonic() is made unconditionally; ideally it would be put in a #ifdef for Mac OS X.
