### PR TITLE
Fix assert error while parsing XML file.

### DIFF
--- a/src/core/TextTools.cc
+++ b/src/core/TextTools.cc
@@ -97,7 +97,10 @@ bool isJapaneseChar(const QChar c, const QChar c2) {
 }
 
 bool isJapaneseChar(const QString &s, int pos) {
-	return isKanaChar(s[pos]) || isKanjiChar(s, pos) || isPunctuationChar(s[pos]);
+    if (s == NULL || pos >= s.size())
+        return false;
+    else
+        return isKanaChar(s[pos]) || isKanjiChar(s, pos) || isPunctuationChar(s[pos]);
 }
 
 bool isRomajiChar(const QChar c) {


### PR DESCRIPTION
This is the issue that we talked together in the mail list about the kanji XML parsing (kanjivg).
The access of the char failed because, on some kanjis, the QString was empty.