### PR TITLE
Avoid using Sqlite statement after it has been finalized.

### DIFF
--- a/src/sqlite/Query.cc
+++ b/src/sqlite/Query.cc
@@ -307,7 +307,6 @@ void Query::clear()
 		checkQueryError(*this, qtext);
 		_stmt = 0;
 	}
-	
 	_state = INVALID;
 	_bindIndex = 0;
 }

--- a/src/sqlite/Query.cc
+++ b/src/sqlite/Query.cc
@@ -301,11 +301,13 @@ bool Query::valueIsNull(int column) const
 void Query::clear()
 {
 	if (_stmt) {
+		QString qtext = queryText();
 		sqlite3_finalize(_stmt);
 		_lastError = _connection->updateError();
-		checkQueryError(*this, queryText());
+		checkQueryError(*this, qtext);
 		_stmt = 0;
 	}
+	
 	_state = INVALID;
 	_bindIndex = 0;
 }


### PR DESCRIPTION
On MSVC12 I encountered a small issue when running the tagainijisho binary without a valid kanji database.
Apparently it is not appreciated to reuse the finalized statement in src/sqlite/Query.cc by making a call to queryText().
See also https://www.sqlite.org/c3ref/finalize.html.

