### PR TITLE
Dark theme fixes

### DIFF
--- a/src/gui/detailed_default.css
+++ b/src/gui/detailed_default.css
@@ -15,6 +15,7 @@ td {
 
 .subinfo {
 	background-color: #ddeedd;
+	color: black;
 	width: 100%;
 }
 

--- a/src/gui/kanjidic2/Kanjidic2EntryFormatter.cc
+++ b/src/gui/kanjidic2/Kanjidic2EntryFormatter.cc
@@ -405,7 +405,7 @@ QString Kanjidic2EntryFormatter::formatHead(const ConstEntryPointer &_entry) con
 
 	QString res(EntryFormatter::formatHead(entry));
 	if (res.isEmpty()) return res;
-	else return QString("<a href=\"drawkanji://?kanji=%1\">").arg(entry->kanji()) + res + "</a>";
+	else return QString(res);
 }
 
 QString Kanjidic2EntryFormatter::formatMeanings(const ConstEntryPointer &_entry) const

--- a/src/gui/kanjidic2/detailed_kanjidic2.css
+++ b/src/gui/kanjidic2/detailed_kanjidic2.css
@@ -1,4 +1,0 @@
-.mainwriting a {
-	color: black;
-	text-decoration: none;
-}


### PR DESCRIPTION
Before:
![](http://b.1339.cf/eiggvez.png)
After:
![](http://b.1339.cf/cyyrkwr.png)

The link in `Kanjidic2EntryFormatter.cc:408` didn't seem to have an effect on anything, so I've deleted it. Removes the need to use CSS workarounds too.
I'm not sure why other SubInfo entries aren't following the CSS rules, I tried looking at the code but I couldn't find the cause.