### PR TITLE
Build translation (.qm) files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(Qt5Core ${QTVERSION} REQUIRED)
 find_package(Qt5Widgets ${QTVERSION} REQUIRED)
 find_package(Qt5PrintSupport ${QTVERSION} REQUIRED)
 find_package(Qt5Network ${QTVERSION} REQUIRED)
+find_package(Qt5LinguistTools ${QTVERSION} REQUIRED)
 # FIXME only required when CMake downloads dictionary files. Not necessary for building from source package.
 find_program(GUNZIP NAMES gunzip REQUIRED)
 

--- a/i18n/CMakeLists.txt
+++ b/i18n/CMakeLists.txt
@@ -6,7 +6,7 @@ foreach(tsfile ${TSFILES})
 	endif()
 endforeach()
 
-#QT_ADD_TRANSLATION(QM_FILES ${TRANSLATIONS_FILES})
+qt5_add_translation(QM_FILES ${TRANSLATIONS_FILES})
 add_custom_target (i18n ALL DEPENDS ${QM_FILES})
 
 set(UI_LANG "")


### PR DESCRIPTION
Translations were not built in the Qt5 version, which also broke install due to the missing .qm files. Readd the Qt5-specific command to build translation files.

Cheers,
Mikko :)