### PR TITLE
Make checkbox 'Nanori' to work properly.

### DIFF
--- a/src/gui/kanjidic2/Kanjidic2EntryFormatter.cc
+++ b/src/gui/kanjidic2/Kanjidic2EntryFormatter.cc
@@ -455,7 +455,7 @@ QString Kanjidic2EntryFormatter::formatNanori(const ConstEntryPointer &_entry) c
 	if (showReadings.value()) {
 		ConstKanjidic2EntryPointer entry(_entry.staticCast<const Kanjidic2Entry>());
 		QStringList nanori = entry->nanoris();
-		if (!nanori.isEmpty())
+		if (!nanori.isEmpty() && showNanori.value())
 			return QString("<b>%1:</b> %2").arg(tr("Nanori")).arg(autoFormat(nanori.join(", ")));
 	}
 	return "";


### PR DESCRIPTION
Preferences -> Character entries -> Display -> Nanori checkbox didn't work properly. Used to show Nanori readings even when disabled. This commit fix it.