### PR TITLE
jmdict: ensure senses are HTML escaped

### DIFF
--- a/src/gui/jmdict/JMdictEntryFormatter.cc
+++ b/src/gui/jmdict/JMdictEntryFormatter.cc
@@ -341,7 +341,7 @@ QString JMdictEntryFormatter::formatSenses(const ConstEntryPointer &_entry) cons
 			str.replace("\n", ", ");
 			if (str.isEmpty()) continue;
 			str[0] = str[0].toUpper();
-			gls << QString("<span class=\"glossbody\"><img src=\"flag:%1\"/> %2.</span>").arg(gloss.lang()).arg(str);
+			gls << QString("<span class=\"glossbody\"><img src=\"flag:%1\"/> %2.</span>").arg(gloss.lang()).arg(str.toHtmlEscaped());
 		}
 		ret += gls.join("<br/>");
 


### PR DESCRIPTION
Fixes #177. Thanks to Mislav Blažević for reporting.

Now, this was a nice bug to get started with this codebase and QT...