### PR TITLE
gui: ensure valid color names in EntryFormatter

### DIFF
--- a/src/gui/EntryFormatter.cc
+++ b/src/gui/EntryFormatter.cc
@@ -67,15 +67,15 @@ EntryFormatter::EntryFormatter(const QString& _cssFile, const QString& _htmlFile
 		_css = QString::fromUtf8(f.readAll());
 	}
 	// Append colors
-	_css += QString(".subinfo {\n\tbackground-color: #%1;\n}\n").arg(
-		(QPalette().color(QPalette::Dark).rgb() & 0xffffff), 0, 16);
-	_css += QString(".subinfo .title {\n\tbackground-color: #%1;\n}\n").arg(
-		(QPalette().color(QPalette::Midlight).rgb() & 0xffffff), 0, 16);
-	_css += QString(".subinfo .contents {\n\tbackground-color: #%1;\n}\n").arg(
-		(QPalette().color(QPalette::Midlight).rgb() & 0xffffff), 0, 16);
-	_css += QString(".notes {\n\tbackground-color: #%1; \n\tcolor: #%2;\n}\n").arg(
-		(QPalette().color(QPalette::ToolTipBase).rgb() & 0xffffff), 0, 16).arg(
-		(QPalette().color(QPalette::ToolTipText).rgb() & 0xffffff), 0, 16);
+	_css += QString(".subinfo {\n\tbackground-color: %1;\n}\n").arg(
+		QPalette().color(QPalette::Dark).name());
+	_css += QString(".subinfo .title {\n\tbackground-color: %1;\n}\n").arg(
+		QPalette().color(QPalette::Midlight).name());
+	_css += QString(".subinfo .contents {\n\tbackground-color: %1;\n}\n").arg(
+		QPalette().color(QPalette::Midlight).name());
+	_css += QString(".notes {\n\tbackground-color: %1; \n\tcolor: %2;\n}\n").arg(
+		QPalette().color(QPalette::ToolTipBase).name()).arg(
+		QPalette().color(QPalette::ToolTipText).name());
 
 	// Append custom CSS if specified
 	if (!_cssFile.isEmpty()) {


### PR DESCRIPTION
Still learning QT stuff... but seems correct to me and the annoying warning is gone. Couldn't find any regressions, but please double check.