### PR TITLE
gui: Check for app-specific AppleLanguages on MacOS

### DIFF
--- a/src/gui/main.cc
+++ b/src/gui/main.cc
@@ -225,7 +225,15 @@ int main(int argc, char *argv[])
 		locale = Lang::preferredGUILanguage.value();
 	// Otherwise try the system default
 	} else {
-		locale = QLocale::system().name().left(2);
+		QString name = QLocale::system().name();
+#ifdef Q_OS_MAC
+		// QLocale::system() ignores per-app configuration on MacOS.
+		QSettings settings;
+		QStringList appleLanguages = settings.value("AppleLanguages").toStringList();
+		if (!appleLanguages.isEmpty())
+			name = appleLanguages.first();
+#endif
+		locale = name.left(2);
 	}
 	QLocale::setDefault(QLocale(locale));
 	

--- a/src/gui/main.cc
+++ b/src/gui/main.cc
@@ -226,7 +226,7 @@ int main(int argc, char *argv[])
 	// Otherwise try the system default
 	} else {
 		QString name = QLocale::system().name();
-#ifdef Q_OS_MAC
+#ifdef Q_OS_OSX
 		// QLocale::system() ignores per-app configuration on MacOS.
 		QSettings settings;
 		QStringList appleLanguages = settings.value("AppleLanguages").toStringList();


### PR DESCRIPTION
On MacOS, users can configure per-app locales via a setting called `AppleLanguages`. `QLocale` doesn't seem to support it (yet?), and `QLocale::system()` returns the OS-wide locale.

This patch checks for existence of the setting and, if available, takes that over the system locale.

And thank you so much for this wonderful piece of software! :)