### PR TITLE
Display Unicode code points in the U+XXXX convention

### DIFF
--- a/src/gui/kanjidic2/Kanjidic2EntryFormatter.cc
+++ b/src/gui/kanjidic2/Kanjidic2EntryFormatter.cc
@@ -344,7 +344,7 @@ void Kanjidic2EntryFormatter::showToolTip(const ConstKanjidic2EntryPointer entry
 		CLOSE_TAB;
 	}
 	if (tooltipShowUnicode.value()) {
-		QString body(tr("<b>Unicode:</b> 0x%1").arg(QString::number(TextTools::singleCharToUnicode(entry->kanji()), 16)));
+		QString body(tr("<b>Unicode:</b> U+%1").arg(QString::number(TextTools::singleCharToUnicode(entry->kanji()), 16).toUpper()));
 		CLOSE_TAB;
 	}
 	if (tooltipShowSKIP.value() && !entry->skipCode().isEmpty()) {
@@ -546,7 +546,7 @@ QString Kanjidic2EntryFormatter::formatUnicode(const ConstEntryPointer &_entry) 
 {
 	ConstKanjidic2EntryPointer entry(_entry.staticCast<const Kanjidic2Entry>());
 	if (showUnicode.value()) {
-		return QString("<b>%1:</b> 0x%2").arg(tr("Unicode")).arg(QString::number(TextTools::singleCharToUnicode(entry->kanji()), 16));
+		return QString("<b>%1:</b> U+%2").arg(tr("Unicode")).arg(QString::number(TextTools::singleCharToUnicode(entry->kanji()), 16).toUpper());
 	}
 	return "";
 }

--- a/src/gui/kanjidic2/Kanjidic2FilterWidget.cc
+++ b/src/gui/kanjidic2/Kanjidic2FilterWidget.cc
@@ -22,6 +22,7 @@
 #include "gui/kanjidic2/Kanjidic2FilterWidget.h"
 #include "gui/kanjidic2/Kanjidic2GUIPlugin.h"
 
+#include <QFont>
 #include <QGroupBox>
 
 static void prepareFourCornerComboBox(QComboBox *box)
@@ -94,9 +95,15 @@ Kanjidic2FilterWidget::Kanjidic2FilterWidget(QWidget *parent) : SearchFilterWidg
 	QGroupBox *unicodeGroupBox = new QGroupBox(tr("Unicode"), this);
 	{
 		QHBoxLayout *hLayout = new QHBoxLayout(unicodeGroupBox);
-		_unicode = new TJSpinBox(unicodeGroupBox, "[0-9a-fA-f]{0,6}", 16);
+		hLayout->setSpacing(0);  // Bring the "U+" and the hex code closer
+		QLabel *label;
+		label = new QLabel("U+", unicodeGroupBox);
+		hLayout->addWidget(label);
+		_unicode = new TJSpinBox(unicodeGroupBox, "[0-9a-fA-F]{0,6}", 16);
 		_unicode->setRange(0, 0x2A6DF);
-		_unicode->setPrefix("0x");
+		QFont font = _unicode->font();
+		font.setCapitalization(QFont::AllUppercase);
+		_unicode->setFont(font);
 		connect(_unicode, SIGNAL(valueChanged(int)), this, SLOT(delayedCommandUpdate()));
 		hLayout->addWidget(_unicode);
 	}


### PR DESCRIPTION
Thanks again for a program I use every single day!

This pull request changes the display of Unicode code points from things like `0x5b57` to the more conventional `U+5B57`. I know this is something purely cosmetic, but to me it always stands out...