### PR TITLE
Add support for copying multiple writings/readings to clipboard

### DIFF
--- a/src/gui/EntryMenu.cc
+++ b/src/gui/EntryMenu.cc
@@ -123,8 +123,7 @@ void EntryMenu::updateStatus(const QList<ConstEntryPointer>& entries)
 			copyReadingAction.setVisible(false);
 		}
 	} else {
-		copyWritingAction.setVisible(false);
-		copyReadingAction.setVisible(false);
+		updateStatusMultiSelect(entries.size());
 	}
 }
 
@@ -133,6 +132,13 @@ void EntryMenu::updateStatus(const ConstEntryPointer& entry)
 	QList<ConstEntryPointer> entries;
 	if (entry) entries << entry;
 	updateStatus(entries);
+}
+
+void EntryMenu::updateStatusMultiSelect(int numSelectedEntries) {
+	copyWritingAction.setVisible(true);
+	copyReadingAction.setVisible(true);
+	copyWritingAction.setText(tr("Copy writings to clipboard"));
+	copyReadingAction.setText(tr("Copy readings to clipboard"));
 }
 
 void EntryMenu::makeLastTagsMenu()

--- a/src/gui/EntryMenu.h
+++ b/src/gui/EntryMenu.h
@@ -77,6 +77,12 @@ public:
 	 * Shortcut method.
 	 */
 	void updateStatus(const ConstEntryPointer& entry);
+	/**
+	 * Enable/disable items based on when multiple entries
+	 * have been selected. Avoids the need for creating the
+	 * list of entries with large selections.
+	 */
+	void updateStatusMultiSelect(int numSelectedEntries);
 
 signals:
 	/**


### PR DESCRIPTION
### Overview
This PR adds support for selecting multiple entries and copying all writings or readings for them to the clipboard. Each copied writing/reading will be separated by `\n`.

It has been tested and verified to work in macOS Ventura 13.3.

### Previous behavior

When selecting a single entry and right-clicking, the context menu shows an option for copying the writing or reading of the entry:

![image](https://user-images.githubusercontent.com/129834842/229742595-079eb5f9-ef47-4369-b471-d57708ae7b19.png)

When selecting more than one entry and right-clicking, the context menu does not show the options for copying to the clipboard:

![image](https://user-images.githubusercontent.com/129834842/229744011-f757b875-4827-4edc-9baa-cd4ff02c7cc3.png)

### Expected new behavior

The behavior for selecting a single entry and right-clicking is exactly the same as previously.

When selecting multiple entries and right-clicking, the context menu now includes options for copying writings or readings for all selected entries:

![image](https://user-images.githubusercontent.com/129834842/229743072-ba7e77b3-a0b2-4cd8-a9c7-93e6d2b575ee.png)

The result of running "Copy writings to clipboard" in this case would be setting the clipboard to:
> 人
> 年
> 大
> 十
> 二
> 本
> 中

Running "Copy readings to clipboard" would set the clipboard to:
> ひと
> とし
> おお-
> とお
> ふた
> もと
> なか

Some details:
* Only the first writing/reading of each entry is copied, so if multiple are present for an entry the others will be excluded. This is the same behavior as for copying a single entry's writing/reading.
* If a selected entry does not have a writing or reading it will be excluded from the generated list (i.e. not represented by an empty line or similar).
* If none of the selected entries has any writing or reading, the options for copying them will still be present. Running that option will copy an empty string to the clipboard.

### Note on the implementation
I first implemented this by doing a scan over all selected entries and changing the context menu to represent the actual number of writings/readings that would be copied. However, this meant that selecting many entries would make the context menu take longer to open, and also selecting more than 250 entries would not work as expected due to a built-in limit on how many selected entries can be processed when opening the context menu. So I instead opted for showing a static menu that always shows the same text, since it was simpler to implement and should suffice.